### PR TITLE
Minor change in junos proxy to accept pillar named username. Few changes in junos module

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -93,13 +93,13 @@ def init(opts):
                     'ssh_config',
                     'normalize'
                    ]
+
+    if 'username' in opts['proxy'].keys():
+        opts['proxy']['user'] = opts['proxy'].pop('username')
     proxy_keys = opts['proxy'].keys()
     for arg in optional_args:
         if arg in proxy_keys:
-            if arg == 'username':
-                args['user'] = opts['proxy'][arg]
-            else:
-                args[arg] = opts['proxy'][arg]
+            args[arg] = opts['proxy'][arg]
 
     thisproxy['conn'] = jnpr.junos.Device(**args)
     thisproxy['conn'].open()

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -81,6 +81,7 @@ def init(opts):
 
     args = { "host" : opts['proxy']['host'] }
     optional_args= ['user',
+                    'username',
                     'password'
                     'port',
                     'gather_facts', 
@@ -95,7 +96,10 @@ def init(opts):
     proxy_keys = opts['proxy'].keys()
     for arg in optional_args:
         if arg in proxy_keys:
-            args[arg] = opts['proxy'][arg]
+            if arg == 'username':
+                args['user'] = opts['proxy'][arg]
+            else:
+                args[arg] = opts['proxy'][arg]
 
     thisproxy['conn'] = jnpr.junos.Device(**args)
     thisproxy['conn'].open()


### PR DESCRIPTION
### What does this PR do?
* Tweaks junos proxy,  so that even if the user provides 'username' in the pillar proxy changes it to 'user' and sends it to PyEZ.
* Change only local copies of facts dictionary in functions facts and facts_refresh
* Minor enhancements in documentation and code.

### What issues does this PR fix or reference?
NA

### Previous Behavior
The username to be provided in the pillar like this:
```
proxy:
  proxytype: junos
  host: 1.1.1.1
  user: xxxx
```
### New Behavior
Username can be specified in both ways:

```
proxy:
  proxytype: junos
  host: 1.1.1.1
  user: xxxx
```
           OR
```
proxy:
  proxytype: junos
  host: 1.1.1.1
  username: xxxx
```

### Tests written?

No
