### PR TITLE
Add safety mechanism in shutdown function and add passwd as valid arg…

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -687,7 +687,6 @@ def shutdown(**kwargs):
 
 
     Parameters:
-
       Optional
         * kwargs:
             * shutdown:

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -82,7 +82,8 @@ def init(opts):
     args = {"host": opts['proxy']['host']}
     optional_args = ['user',
                      'username',
-                     'password'
+                     'password',
+                     'passwd',
                      'port',
                      'gather_facts',
                      'mode',


### PR DESCRIPTION
### What does this PR do?
* Makes it mandatory to give shutdown or reboot as an argument in shutdown function.
* Adds 'passwd' as a valid pillar.

### What issues does this PR fix or reference?
NA

### Previous Behavior
* No arguments were required in shutdown function.
* This was invalid:
```
proxy:
  proxytype: junos
  host: 1.1.1.1
  user: xxxxxxx
  passwd: secret123
```

### New Behavior
* shutdown or reboot is mandatory as an argument in shutdown function.
* Now, this is valid:
```
proxy:
  proxytype: junos
  host: 1.1.1.1
  user: xxxxxxx
  passwd: secret123
```

### Tests written?
No