### PR TITLE
Modify install_config to take jinja variables as a plain dictionary.

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -762,7 +762,6 @@ def install_config(path=None, **kwargs):
 
 
     Parameters:
-      Required
         * path:
           Path where the configuration file is present. If the file has a \
           '*.conf' extension,
@@ -771,8 +770,12 @@ def install_config(path=None, **kwargs):
           the content is treated as XML format. If the file has a '*.set' \
           extension,
           the content is treated as Junos OS 'set' commands.(default = None)
-      Optional
         * kwargs: Keyworded arguments which can be provided like-
+            * template_path:
+              Path where the jinja template is present on the master.
+            * template_vars:
+              The dictionary of data for the jinja variables present in the \
+              jinja template
             * dev_timeout:
               Set NETCONF RPC timeout. Can be used for commands which
               take a while to execute. (default = 30 seconds)
@@ -840,7 +843,7 @@ def install_config(path=None, **kwargs):
         ret['message'] = 'Invalid file path.'
         ret['out'] = False
         return ret
-    
+
     if os.path.getsize(template_cached_path) == 0:
         ret['message'] = 'Template failed to render'
         ret['out'] = False

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -259,15 +259,29 @@ def install_config(name, path=None, **kwargs):
 
     .. code-block:: yaml
 
-            salt://configs/interface.set:
+            Install the mentioned config:
               junos:
                 - install_config
+                - path: salt//configs/interface.set
                 - timeout: 100
                 - diffs_file: 'var/log/diff'
 
+
+    .. code-block:: yaml
+
+            Install the mentioned config:
+              junos:
+                - install_config
+                - template_path: salt//configs/interface.set
+                - timeout: 100
+                - template_vars:
+                    interface_name: lo0
+                    description: Creating interface via SaltStack.
+
+
     Parameters:
       Required
-        * path:
+        * path or template_path (Either one of the keyword must be there):
           Path where the configuration file is present. If the file has a \
           '*.conf' extension,
           the content is treated as text format. If the file has a '*.xml' \
@@ -277,6 +291,11 @@ def install_config(name, path=None, **kwargs):
           the content is treated as Junos OS 'set' commands.(default = None)
       Optional
         * kwargs: Keyworded arguments which can be provided like-
+            * template_path:
+              Path where the jinja template is present on the master.
+            * template_vars:
+              The dictionary of data for the jinja variables present in the \
+              jinja template
             * timeout:
               Set NETCONF RPC timeout. Can be used for commands which
               take a while to execute. (default = 30 seconds)

--- a/salt/states/junos.py
+++ b/salt/states/junos.py
@@ -253,7 +253,7 @@ def shutdown(name, **kwargs):
     return ret
 
 
-def install_config(name, **kwargs):
+def install_config(name, path=None, **kwargs):
     '''
     Loads and commits the configuration provided.
 
@@ -301,7 +301,7 @@ def install_config(name, **kwargs):
               :py:func:`cp.push <salt.modules.cp.push>`
     '''
     ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
-    ret['changes'] = __salt__['junos.install_config'](name, **kwargs)
+    ret['changes'] = __salt__['junos.install_config'](path, **kwargs)
     return ret
 
 


### PR DESCRIPTION
### What does this PR do?
* Change install_config execution module to accept jinja variables from a dictionary.
* Jinja variables can be given in the sls file itself.
* Modify install_config state module to make path a keyword.

### What issues does this PR fix or reference?
NA

### Previous Behavior
* The jinja variables had to be in the grains or pillars.
* For install_config state module, the name was the path of the config file:
```
salt://my_config.set:
  junos:
    - install_config
```

### New Behavior
* One can specify variables directly in sls file have a dictionary in template_vars.
```
Install config:
  junos:
    - install_config
    - template_path: salt://interface.set
    - template_vars: 
          interface_name: lo0
          description: Created via salt
```
* path keyword has to specified in the sls:
```
State name:
  junos:
    - install_config
    - path: salt://my_config.set
```

### Tests written?
No