### PR TITLE
allow extra template variables to be passed into install_config

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -764,7 +764,7 @@ def install_config(path=None, **kwargs):
     Parameters:
       Required
         * path:
-          Path where the configuration file is present. If the file has a \
+          Path where the configuration/template file is present. If the file has a \
           '*.conf' extension,
           the content is treated as text format. If the file has a '*.xml' \
           extension,
@@ -797,8 +797,8 @@ def install_config(path=None, **kwargs):
               :py:func:`cp.push <salt.modules.cp.push>`
             * template_vars:
               Variables to be passed into the template processing engine in addition
-              to those present in __pillar__, __opts__, __grains__, etc. You may reference these variables like so:
-              {{ template_vars["var_name"] }}
+              to those present in __pillar__, __opts__, __grains__, etc. You may reference these variables
+              in your template like so: {{ template_vars["var_name"] }}
 
     '''
     conn = __proxy__['junos.conn']()


### PR DESCRIPTION
### What does this PR do?
Allows extra variables to be passed into the install_config function 

### What issues does this PR fix or reference?
N/A

### Previous Behavior
Only variables available in pillar, opts, or grains were available as variables

### New Behavior
template_vars can now be specified on the cli or via local.cmd

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
