### PR TITLE
Junos syslog daemon bug 001

### DIFF
--- a/salt/engines/junos_syslog.py
+++ b/salt/engines/junos_syslog.py
@@ -121,7 +121,7 @@ class Parser(object):
         hostname = Word(alphas + nums + "_" + "-" + ".")
 
         # daemon
-        daemon = Word(alphas + "/" + "-" + "_" + ".") + Optional(
+        daemon = Word(alphas + nums + "/" + "-" + "_" + ".") + Optional(
             Suppress("[") + ints + Suppress("]")) + Suppress(":")
 
         # message

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -764,7 +764,7 @@ def install_config(path=None, **kwargs):
     Parameters:
       Required
         * path:
-          Path where the configuration file is present. If the file has a \
+          Path where the configuration/template file is present. If the file has a \
           '*.conf' extension,
           the content is treated as text format. If the file has a '*.xml' \
           extension,
@@ -797,8 +797,8 @@ def install_config(path=None, **kwargs):
               :py:func:`cp.push <salt.modules.cp.push>`
             * template_vars:
               Variables to be passed into the template processing engine in addition
-              to those present in __pillar__, __opts__, __grains__, etc. You may reference these variables like so:
-              {{ template_vars["var_name"] }}
+              to those present in __pillar__, __opts__, __grains__, etc. You may reference these variables
+              in your template like so: {{ template_vars["var_name"] }}
 
     '''
     conn = __proxy__['junos.conn']()


### PR DESCRIPTION
### What does this PR do?

This pull request fixes a parser bug that would show deamons with digits in the name as 'unkown' and an event of 'system', i.e. mib2d. The following event was incorrectly being parsed:

<30>Feb 16 19:59:14 EX2200c mib2d[1195]: SNMP_TRAP_LINK_UP: ifIndex 514, ifAdminStatus up(1), ifOperStatus up(1), ifName ge-0/0/4.0"

The parser for the daemon field was only allowing for alphas and some special chars

### What issues does this PR fix or reference?
incorrect parsing for deamons such as mib2d

### Previous Behavior
SNMP_TRAP_LINK_UP/DOWN would be sent as SYSTEM events incorrectly 

### New Behavior
The event and daemon are correctly parsed and sent onto the event bus

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
