### PR TITLE
Remove usage of nose in junos unit tests

### DIFF
--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 __author__ = "Rajvi Dhimar"
 
 import unittest
-from nose.plugins.attrib import attr
 from tests.support.mock import patch, mock_open
 try:
     from lxml import etree
@@ -18,8 +17,6 @@ from jnpr.junos.utils.sw import SW
 from jnpr.junos.device import Device
 import salt.modules.junos as junos
 
-
-@attr('unit')
 class Test_Junos_Module(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
### What does this PR do?
As Saltstack is moving away from nose, removing it's usage from junos unit tests.

### What issues does this PR fix or reference?
NA

### Previous Behavior
NA

### New Behavior
NA

### Tests written?
NA
