### PR TITLE
Take care of import error and add condition to skip tests if PyEZ is …

### DIFF
--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -5,19 +5,24 @@ from __future__ import print_function
 
 __author__ = "Rajvi Dhimar"
 
-import unittest
 from tests.support.mock import patch, mock_open
+from tests.support.unit import skipIf, TestCase
 try:
     from lxml import etree
 except ImportError:
     from salt._compat import ElementTree as etree
 
-from jnpr.junos.utils.config import Config
-from jnpr.junos.utils.sw import SW
-from jnpr.junos.device import Device
+try:
+    from jnpr.junos.utils.config import Config
+    from jnpr.junos.utils.sw import SW
+    from jnpr.junos.device import Device
+    HAS_JUNOS = True
+except ImportError:
+    HAS_JUNOS = False
 import salt.modules.junos as junos
 
-class Test_Junos_Module(unittest.TestCase):
+@skipIf(not HAS_JUNOS, 'Missing dependencies')
+class Test_Junos_Module(TestCase):
 
     def setUp(self):
         junos.__proxy__ = {


### PR DESCRIPTION
…not installed

### What does this PR do?
* Exception handling where junos-eznc is imported.
* Skip tests if junos-eznc is not installed on the system

### What issues does this PR fix or reference?
NA

### Previous Behavior
An exception occurred if PyEZ was not installed on the system.

### New Behavior
The exception is handled and  the tests are not run if the 

### Tests written?
NA
