### PR TITLE
Correct the junos unit tests which mock getattr

### DIFF
--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -1571,10 +1571,9 @@ class Test_Junos_Module(TestCase):
         ret['out'] = False
         self.assertEqual(junos.rpc(), ret)
 
-    @skipIf(True, 'This @patch decorator stacktraces as written. This test needs to be updated.')
-    @patch('salt.modules.junos.getattr')
-    def test_rpc_get_config_exception(self, mock_attr):
-        mock_attr.return_value = self.raise_exception
+    @patch('jnpr.junos.device.Device.execute')
+    def test_rpc_get_config_exception(self, mock_execute):
+        mock_execute.side_effect = self.raise_exception
         ret = dict()
         ret['message'] = 'RPC execution failed due to "Test exception"'
         ret['out'] = False
@@ -1642,11 +1641,10 @@ class Test_Junos_Module(TestCase):
         mock_warning.assert_called_with(
             'Filter ignored as it is only used with "get-config" rpc')
 
-    @skipIf(True, 'This @patch decorator stacktraces as written. This test needs to be updated.')
-    @patch('salt.modules.junos.getattr')
+    @patch('jnpr.junos.device.Device.execute')
     def test_rpc_get_interface_information_exception(
-            self, mock_attr):
-        mock_attr.return_value = self.raise_exception
+            self, mock_execute):
+        mock_execute.side_effect = self.raise_exception
         ret = dict()
         ret['message'] = 'RPC execution failed due to "Test exception"'
         ret['out'] = False


### PR DESCRIPTION
### What does this PR do?
It fixes two junos unit tests which were skipped as they mocked the builtin getattr, which is not the correct way.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/40425

### Previous Behavior
Two of junos unit test were skipped as they were causing trouble.

### New Behavior
The two tests will run normally.

### Tests written?
NA
