### PR TITLE
Bug fix for keep_alive feature of junos.

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -128,6 +128,11 @@ def alive(opts):
     '''
 
     dev = conn()
+    
+    # Check that the underlying netconf connection still exists.
+    if dev._conn is None:
+        return False
+
     # call rpc only if ncclient queue is empty. If not empty that means other
     # rpc call is going on.
     if hasattr(dev._conn, '_session'):


### PR DESCRIPTION
### What does this PR do?
There was a bug with keep_alive of junos proxy. 
In the alive function, even if the netconf connection didn't exist we call ping() which tries to fire an rpc over that connection, resulting in an exception.
This PR solves the problem by checking if the connection is still there or not.

### What issues does this PR fix or reference?
NA

### Previous Behavior
If there was no connection with the junos device, the alive() function errored out.

### New Behavior
If there is no connection, the alive() function will return False. Salt will try to re-establish the connection.

### Tests written?
No

