### PR TITLE
Fix junos rpc to work with scheduler jobs.

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -27,6 +27,7 @@ except ImportError:
 
 # Import Salt libs
 import salt.utils.files
+from salt.ext import six
 
 # Juniper interface libraries
 # https://github.com/Juniper/py-junos-eznc
@@ -176,6 +177,10 @@ def rpc(cmd=None, dest=None, format='xml', **kwargs):
         if kwargs['__pub_arg']:
             if isinstance(kwargs['__pub_arg'][-1], dict):
                 op.update(kwargs['__pub_arg'][-1])
+    elif '__pub_schedule' in kwargs:
+        for key, value in six.iteritems(kwargs):
+            if not key.startswith('__pub_'):
+                op[key] = value
     else:
         op.update(kwargs)
     op['dev_timeout'] = str(op.pop('timeout', conn.timeout))

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -128,6 +128,11 @@ def alive(opts):
     '''
 
     dev = conn()
+    
+    # Check that the underlying netconf connection still exists.
+    if dev._conn is None:
+        return False
+
     # call rpc only if ncclient queue is empty. If not empty that means other
     # rpc call is going on.
     if hasattr(dev._conn, '_session'):


### PR DESCRIPTION
### What does this PR do?
The 'rpc' function of did not work properly when we used to schedule a job which runs junos rpc. 
This PR fixes that issue.

### What issues does this PR fix or reference?
NA

### Previous Behavior
When we added a job in scheduler like this one:
```
salt 'dev' schedule.add rpc_job function='junos.rpc' job_args="[get-interface-information]" job_kwargs="{'interface_name':'lo0'}" seconds=10
```
The scheduled job would error out giving this error:
```
'return': {'message': 'RPC execution failed due to "Invalid tag name u\'--pub-pid\'"', 'out': False}
```

### New Behavior
Once we schedule a job via cli:
```
salt 'dev' schedule.add rpc_job function='junos.rpc' job_args="[get-interface-information]" job_kwargs="{'interface_name':'lo0'}" seconds=10
```
Or in in a state file:
```
rpc_job:
  schedule.present:
    - function: junos.rpc
    - job_args:
        - get_interface_information
    - job_kwargs:
        interface_name: lo0
        terse: True
    - seconds: 10
```

### Tests written?
No

