### PR TITLE
exception handling around SW class binding

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -114,7 +114,10 @@ def init(opts):
         thisproxy['initialized'] = False
         return
     thisproxy['conn'].bind(cu=jnpr.junos.utils.config.Config)
-    thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
+    try:
+        thisproxy['conn'].bind(sw=jnpr.junos.utils.sw.SW)
+    except Exception as ex:
+        log.error('Bind failed with SW class due to: %s' % ex)
     thisproxy['initialized'] = True
 
 


### PR DESCRIPTION
### What does this PR do?
proxy open is clean

### What issues does this PR fix or reference?
SW class binding used to fail in open if facts were not full

### New Behavior
junos.install_os will only fail if facts are not full, but proxy will come up properly

### Tests written?
No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
