### PR TITLE
also to support config related table/view

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -46,6 +46,7 @@ try:
     import jnpr.junos.op as tables_dir
     from jnpr.junos.factory.factory_loader import FactoryLoader
     from jnpr.junos.factory.optable import OpTable
+    from jnpr.junos.factory.cfgtable import CfgTable
     from jnpr.junos.exception import ConnectClosedError
     import jxmlease
     import yamlordereddictloader
@@ -1404,7 +1405,7 @@ def get_table(table, file, path=None, target=None, key=None, key_items=None,
             ret['out'] = False
             return ret
         ret['reply'] = json.loads(data.to_json())
-        if data.__class__.__bases__[0] == OpTable:
+        if data.__class__.__bases__[0] in [OpTable, CfgTable]:
             # Sets key value if not present in YAML. To be used by returner
             if ret['table'][table].get('key') is None:
                 ret['table'][table]['key'] = data.ITEM_NAME_XPATH


### PR DESCRIPTION
### What does this PR do?

to support config related table/view

### What issues does this PR fix or reference?

Error when config table/view was called from junos.get_table

### Previous Behavior
it used to error like below
```
sionListener object at 0x7fc6297814e0>: <rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/18.2R1/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:dd645454-f4b9-4966-beaa-e3a9c11576a9">
<configuration xmlns="http://xml.juniper.net/xnm/1.1/xnm" junos:changed-seconds="1540465122" junos:changed-localtime="2018-10-25 16:28:42 IST">
    <system>
        <services>
            <finger junos:group="global">
            </finger>
            <ftp junos:group="global">
            </ftp>
            <undocumented><rlogin junos:group="global">
            </rlogin></undocumented>
            <ssh junos:group="global">
                <root-login junos:group="global">allow</root-login>
            </ssh>
            <telnet junos:group="global">
            </telnet>
            <xnm-clear-text junos:group="global">
            </xnm-clear-text>
            <extension-service>
                <request-response>
                    <grpc>
                        <undocumented><clear-text>
                        </clear-text></undocumented>
                        <undocumented><skip-authentication/></undocumented>
                    </grpc>
                </request-response>
            </extension-service>
            <netconf>
                <ssh>
                </ssh>
            </netconf>
        </services>
    </system>
</configuration>
</rpc-reply>
[DEBUG   ] Minion return retry timer set to 8 seconds (randomized)
[DEBUG   ] [host 10.221.129.144 session-id 27133] Trying another round of parsing since there is still data
[INFO    ] Returning information for job: 20181026101904216008
[DEBUG   ] [host 10.221.129.144 session-id 27133] parsing netconf v1.0
[DEBUG   ] Initializing new AsyncZeroMQReqChannel for ('/etc/salt/pki/proxy', 'proxy01', 'tcp://127.0.0.1:4506', 'aes')
[DEBUG   ] Initializing new AsyncAuth for ('/etc/salt/pki/proxy', 'proxy01', 'tcp://127.0.0.1:4506')
[DEBUG   ] Connecting the Minion to the Master URI (for the return server): tcp://127.0.0.1:4506
[DEBUG   ] Trying to connect to: tcp://127.0.0.1:4506
Exception in thread 20181026101904216008:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.6/dist-packages/salt/minion.py", line 3758, in _target
    Minion._thread_return(minion_instance, opts, data)
  File "/usr/local/lib/python3.6/dist-packages/salt/minion.py", line 1709, in _thread_return
    timeout=minion_instance._return_retry_timer()
  File "/usr/local/lib/python3.6/dist-packages/salt/minion.py", line 1930, in _return_pub
    ret_val = self._send_req_sync(load, timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/salt/minion.py", line 1376, in _send_req_sync
    return channel.send(load, timeout=timeout)
  File "/usr/local/lib/python3.6/dist-packages/salt/utils/async.py", line 75, in wrap
    ret = self._block_future(ret)
  File "/usr/local/lib/python3.6/dist-packages/salt/utils/async.py", line 85, in _block_future
    return future.result()
  File "/usr/local/lib/python3.6/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 1063, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python3.6/dist-packages/salt/transport/zeromq.py", line 320, in send
    ret = yield self._crypted_transfer(load, tries=tries, timeout=timeout, raw=raw)
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/usr/local/lib/python3.6/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 1063, in run
    yielded = self.gen.throw(*exc_info)
  File "/usr/local/lib/python3.6/dist-packages/salt/transport/zeromq.py", line 288, in _crypted_transfer
    ret = yield _do_transfer()
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 1055, in run
    value = future.result()
  File "/usr/local/lib/python3.6/dist-packages/tornado/concurrent.py", line 238, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "/usr/local/lib/python3.6/dist-packages/tornado/gen.py", line 307, in wrapper
    yielded = next(result)
  File "/usr/local/lib/python3.6/dist-packages/salt/transport/zeromq.py", line 270, in _do_transfer
    self._package_load(self.auth.crypticle.dumps(load)),
  File "/usr/local/lib/python3.6/dist-packages/salt/crypt.py", line 1348, in dumps
    return self.encrypt(self.PICKLE_PAD + self.serial.dumps(obj))
  File "/usr/local/lib/python3.6/dist-packages/salt/payload.py", line 184, in dumps
    return msgpack.dumps(msg, use_bin_type=use_bin_type)
  File "/usr/local/lib/python3.6/dist-packages/msgpack/__init__.py", line 47, in packb
    return Packer(**kwargs).pack(o)
  File "msgpack/_packer.pyx", line 284, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 290, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 287, in msgpack._packer.Packer.pack
  File "msgpack/_packer.pyx", line 234, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 234, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 234, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 245, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 245, in msgpack._packer.Packer._pack
  File "msgpack/_packer.pyx", line 281, in msgpack._packer.Packer._pack
TypeError: can't serialize <class 'jnpr.junos.factory.View.NetconfSSHView'>```

### New Behavior
proper JSON data bein returned

