### PR TITLE
Upgrade install module to match PyEZ's capability

### DIFF
--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1051,26 +1051,6 @@ def install_os(path=None, **kwargs):
     ret = {}
     ret['out'] = True
 
-    if path is None:
-        ret['message'] = \
-            'Please provide the salt path where the junos image is present.'
-        ret['out'] = False
-        return ret
-
-    image_cached_path = salt.utils.files.mkstemp()
-    __salt__['cp.get_file'](path, image_cached_path)
-
-    if not os.path.isfile(image_cached_path):
-        ret['message'] = 'Invalid image path.'
-        ret['out'] = False
-        return ret
-
-    if os.path.getsize(image_cached_path) == 0:
-        ret['message'] = 'Failed to copy image'
-        ret['out'] = False
-        return ret
-    path = image_cached_path
-
     op = {}
     if '__pub_arg' in kwargs:
         if kwargs['__pub_arg']:
@@ -1078,6 +1058,29 @@ def install_os(path=None, **kwargs):
                 op.update(kwargs['__pub_arg'][-1])
     else:
         op.update(kwargs)
+
+    no_copy_ = op.get('no_copy', False)
+
+    if path is None:
+        ret['message'] = \
+            'Please provide the salt path where the junos image is present.'
+        ret['out'] = False
+        return ret
+
+    if not no_copy_:
+        image_cached_path = salt.utils.files.mkstemp()
+        __salt__['cp.get_file'](path, image_cached_path)
+
+        if not os.path.isfile(image_cached_path):
+            ret['message'] = 'Invalid image path.'
+            ret['out'] = False
+            return ret
+
+        if os.path.getsize(image_cached_path) == 0:
+            ret['message'] = 'Failed to copy image'
+            ret['out'] = False
+            return ret
+        path = image_cached_path
 
     try:
         conn.sw.install(path, progress=True, **op)
@@ -1087,7 +1090,8 @@ def install_os(path=None, **kwargs):
         ret['out'] = False
         return ret
     finally:
-        salt.utils.files.safe_rm(image_cached_path)
+        if not no_copy_:
+            salt.utils.files.safe_rm(image_cached_path)
 
     if 'reboot' in op and op['reboot'] is True:
         try:

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -1003,6 +1003,13 @@ def install_os(path=None, **kwargs):
     path (required)
         Path where the image file is present on the proxy minion
 
+    remote_path :
+        If the value of path  is a file path on the local
+        (Salt host's) filesystem, then the image is copied from the local
+        filesystem to the :remote_path: directory on the target Junos
+        device. The default is ``/var/tmp``. If the value of :path: or
+        is a URL, then the value of :remote_path: is unused.
+
     dev_timeout : 30
         The NETCONF RPC timeout (in seconds). This argument was added since most of
         the time the "package add" RPC takes a significant amount of time.  The default
@@ -1015,6 +1022,23 @@ def install_os(path=None, **kwargs):
 
     no_copy : False
         If ``True`` the software package will not be SCP’d to the device
+
+    bool validate:
+        When ``True`` this method will perform a config validation against
+        the new image
+
+    bool issu:
+        When ``True`` allows unified in-service software upgrade
+        (ISSU) feature enables you to upgrade between two different Junos OS
+        releases with no disruption on the control plane and with minimal
+        disruption of traffic.
+
+    bool nssu:
+        When ``True`` allows nonstop software upgrade (NSSU)
+        enables you to upgrade the software running on a Juniper Networks
+        EX Series Virtual Chassis or a Juniper Networks EX Series Ethernet
+        Switch with redundant Routing Engines with a single command and
+        minimal disruption to network traffic.
 
     CLI Examples:
 
@@ -1056,7 +1080,7 @@ def install_os(path=None, **kwargs):
         op.update(kwargs)
 
     try:
-        conn.sw.install(path, progress=True)
+        conn.sw.install(path, progress=True, **op)
         ret['message'] = 'Installed the os.'
     except Exception as exception:
         ret['message'] = 'Installation failed due to: "{0}"'.format(exception)

--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -189,6 +189,20 @@ def proxytype():
     return 'junos'
 
 
+def get_serialized_facts():
+    facts = dict(thisproxy['conn'].facts)
+    if 'version_info' in facts:
+        facts['version_info'] = \
+            dict(facts['version_info'])
+    # For backward compatibility. 'junos_info' is present
+    # only of in newer versions of facts.
+    if 'junos_info' in facts:
+        for re in facts['junos_info']:
+            facts['junos_info'][re]['object'] = \
+                dict(facts['junos_info'][re]['object'])
+    return facts
+
+
 def shutdown(opts):
     '''
     This is called when the proxy-minion is exiting to make sure the

--- a/tests/unit/modules/test_junos.py
+++ b/tests/unit/modules/test_junos.py
@@ -8,7 +8,7 @@ import os
 
 # Import test libs
 from tests.support.mixins import LoaderModuleMockMixin, XMLEqualityMixin
-from tests.support.mock import patch, mock_open, PropertyMock, call
+from tests.support.mock import patch, mock_open, PropertyMock, call, ANY
 from tests.support.unit import skipIf, TestCase
 
 # Import 3rd-party libs
@@ -1316,6 +1316,51 @@ class Test_Junos_Module(TestCase, LoaderModuleMockMixin, XMLEqualityMixin):
                 'Installation successful but reboot failed due to : "Test exception"'
             ret['out'] = False
             self.assertEqual(junos.install_os('path', **args), ret)
+
+    def test_install_os_no_copy(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            self.assertEqual(junos.install_os('path', no_copy=True), ret)
+            mock_install.assert_called_with(u'path', no_copy=True, progress=True)
+            mock_mkstemp.assert_not_called()
+            mock_safe_rm.assert_not_called()
+
+    def test_install_os_issu(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            self.assertEqual(junos.install_os('path', issu=True), ret)
+            mock_install.assert_called_with(ANY, issu=True, progress=True)
+
+    def test_install_os_add_params(self):
+        with patch('jnpr.junos.utils.sw.SW.install') as mock_install, \
+                patch('salt.utils.files.safe_rm') as mock_safe_rm, \
+                patch('salt.utils.files.mkstemp') as mock_mkstemp, \
+                patch('os.path.isfile') as mock_isfile, \
+                patch('os.path.getsize') as mock_getsize:
+            mock_getsize.return_value = 10
+            mock_isfile.return_value = True
+            ret = dict()
+            ret['out'] = True
+            ret['message'] = 'Installed the os.'
+            remote_path = '/path/to/file'
+            self.assertEqual(junos.install_os('path', remote_path=remote_path, nssu=True, validate=True), ret)
+            mock_install.assert_called_with(ANY, nssu=True, remote_path=remote_path, progress=True, validate=True)
 
     def test_file_copy_without_args(self):
         ret = dict()


### PR DESCRIPTION
### What does this PR do?
Added new parameters to junos.install:
*  `remote_path` 
* `validate`
* `issu`
* `nssu`

Fixed exixsting parameters:
* `no_copy`

Changed keep alive function to ping if and only if both receiving queue and sending queue are empty

### What issues does this PR fix or reference?
Resolves #38 

### Previous Behavior
no_copy was not being passed to underlying PyEZ functionality, hence broken

### Tests written?
No