### PR TITLE
Update junos_syslog.py

### DIFF
--- a/salt/engines/junos_syslog.py
+++ b/salt/engines/junos_syslog.py
@@ -299,7 +299,7 @@ class _SyslogServerFactory(DatagramProtocol):
                  if the event is to be sent on the bus.
 
         '''
-        data = self.obj.parse(data)
+        data = self.obj.parse(data.decode())
         data['hostip'] = host
         log.debug(
             'Junos Syslog - received %s from %s, sent from port %s',


### PR DESCRIPTION
### What does this PR do?
Call decode() function on input `data` before trying to parse it.

### What issues does this PR fix or reference?
Fixes #126 

### Tests Results
#### Python2
```
[DEBUG   ] Sending event: tag = jnpr/syslog/R1_re0/UI_COMMIT_PROGRESS; data = {u'daemon': u'mgd', u'severity': 6, u'facility': 23, u'timestamp': '2019-07-01 11:34:38', u'hostname': u'R1_re0', u'pid': u'28641', u'_stamp': '2019-07-01T06:04:38.469718', u'priority': 190, u'raw': "<190>Jun 27 16:51:21 R1_re0 mgd[28641]: UI_COMMIT_PROGRESS: Commit operation in progress: signaling 'Alarm control process', pid 16483, signal 30, status 0 with notification errors enabled\n", u'hostip': '127.0.0.1', u'message': u"Commit operation in progress: signaling 'Alarm control process', pid 16483, signal 30, status 0 with notification errors enabled", u'event': u'UI_COMMIT_PROGRESS'}
```

#### Python3
```
[DEBUG   ] Junos Syslog - sending this event on the bus: {'priority': 190, 'severity': 6, 'facility': 23, 'timestamp': '2019-07-01 11:32:35', 'hostname': 'R1_re0', 'daemon': 'mgd', 'pid': '28641', 'message': "Commit operation in progress: signaling 'Alarm control process', pid 16483, signal 30, status 0 with notification errors enabled", 'event': 'UI_COMMIT_PROGRESS', 'raw': b"<190>Jun 27 16:51:21 R1_re0 mgd[28641]: UI_COMMIT_PROGRESS: Commit operation in progress: signaling 'Alarm control process', pid 16483, signal 30, status 0 with notification errors enabled\n", 'hostip': '127.0.0.1'} from 127.0.0.1
```
