### PR TITLE
Add sock_fd  in optional_args

### DIFF
--- a/salt/proxy/junos.py
+++ b/salt/proxy/junos.py
@@ -120,6 +120,7 @@ def init(opts):
         "normalize",
         "huge_tree",
         "use_filter",
+        "sock_fd"
     ]
 
     if "username" in opts["proxy"].keys():


### PR DESCRIPTION
sock_fd is not picked up even if it was passed in the pillar file. Adding it in the optional_args

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
